### PR TITLE
NullPointerException fix for unit tests

### DIFF
--- a/test/lunatech/lunchplanner/controllers/DishControllerSpec.scala
+++ b/test/lunatech/lunchplanner/controllers/DishControllerSpec.scala
@@ -4,16 +4,17 @@ import java.util
 import java.util.UUID
 
 import akka.stream.Materializer
-import lunatech.lunchplanner.common.{ ControllerSpec, DBConnection }
+import com.typesafe.config.ConfigFactory
+import lunatech.lunchplanner.common.{ControllerSpec, DBConnection}
 import lunatech.lunchplanner.data.ControllersData._
 import lunatech.lunchplanner.models.User
 import lunatech.lunchplanner.persistence.DishTable
-import lunatech.lunchplanner.services.{ DishService, MenuDishService, UserService }
+import lunatech.lunchplanner.services.{DishService, MenuDishService, UserService}
 import org.mockito.Mockito._
-import play.api.i18n.MessagesApi
+import play.api.i18n.{DefaultLangs, DefaultMessagesApi}
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{ call, status, _ }
-import play.api.{ Configuration, Environment }
+import play.api.test.Helpers.{call, status, _}
+import play.api.{Configuration, Environment}
 import slick.lifted.TableQuery
 
 import scala.concurrent.Future
@@ -21,13 +22,15 @@ import scala.concurrent.Future
 class DishControllerSpec extends ControllerSpec {
   implicit lazy val materializer: Materializer = app.materializer
 
+  val config = Configuration(ConfigFactory.load())
+
   private val developer = User(UUID.randomUUID(), "Developer", "developer@lunatech.com")
 
   val userService = mock[UserService]
   val dishService = mock[DishService]
   val menuDishService = mock[MenuDishService]
   val environment = mock[Environment]
-  val messagesApi = mock[MessagesApi]
+  val messagesApi = new DefaultMessagesApi(Environment.simple(), config, new DefaultLangs(config))
   val configuration = mock[Configuration]
   val connection = mock[DBConnection]
 

--- a/test/lunatech/lunchplanner/controllers/MenuControllerSpec.scala
+++ b/test/lunatech/lunchplanner/controllers/MenuControllerSpec.scala
@@ -4,22 +4,25 @@ import java.util
 import java.util.UUID
 
 import akka.stream.Materializer
-import lunatech.lunchplanner.common.{ ControllerSpec, DBConnection }
+import com.typesafe.config.ConfigFactory
+import lunatech.lunchplanner.common.{ControllerSpec, DBConnection}
 import lunatech.lunchplanner.data.ControllersData._
 import lunatech.lunchplanner.models.User
 import lunatech.lunchplanner.persistence.DishTable
-import lunatech.lunchplanner.services.{ DishService, MenuDishService, MenuPerDayPerPersonService, MenuPerDayService, MenuService, UserService }
+import lunatech.lunchplanner.services._
 import org.mockito.Mockito._
-import play.api.i18n.MessagesApi
+import play.api.i18n.{DefaultLangs, DefaultMessagesApi}
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{ call, status, _ }
-import play.api.{ Configuration, Environment }
+import play.api.test.Helpers.{call, status, _}
+import play.api.{Configuration, Environment}
 import slick.lifted.TableQuery
 
 import scala.concurrent.Future
 
 class MenuControllerSpec extends ControllerSpec {
   implicit lazy val materializer: Materializer = app.materializer
+
+  val config = Configuration(ConfigFactory.load)
 
   private val developer = User(UUID.randomUUID(), "Developer", "developer@lunatech.com")
 
@@ -30,7 +33,7 @@ class MenuControllerSpec extends ControllerSpec {
   val menuPerDayService = mock[MenuPerDayService]
   val menuPerDayPerPersonService = mock[MenuPerDayPerPersonService]
   val environment = mock[Environment]
-  val messagesApi = mock[MessagesApi]
+  val messagesApi = new DefaultMessagesApi(Environment.simple(), config, new DefaultLangs(config))
   val configuration = mock[Configuration]
   val connection = mock[DBConnection]
 


### PR DESCRIPTION
I finally found the solution for this issue. The thing is, we cannot just declare a mock for i18n.MessagesApi. If we want to completely mock it, we need to stub its other methods before we can use it.

Good thing that there's a `DefaultMessagesApi` that we can use for instantiating `messagesApi`. 