### PR TITLE
Add slick-hikaricp dependency to project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.6.8",
   "com.typesafe.play" %% "play-slick" % "3.0.3",
   "com.typesafe.play" %% "play-slick-evolutions" % "3.0.3",
+  "com.typesafe.slick" %% "slick-hikaricp" % "3.2.0",
   "org.postgresql" % "postgresql" % "9.3-1102-jdbc41",
   "com.typesafe.slick" %% "slick" % "3.2.1",
   "com.google.api-client" % "google-api-client" % "1.22.0",


### PR DESCRIPTION
Add slick-hikaricp dependency to project. This may be missing to ensure the automatic db connection pool configuration