### PR TITLE
Upgrade slick-hiraricp version to 3.2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.6.8",
   "com.typesafe.play" %% "play-slick" % "3.0.3",
   "com.typesafe.play" %% "play-slick-evolutions" % "3.0.3",
-  "com.typesafe.slick" %% "slick-hikaricp" % "3.2.0",
+  "com.typesafe.slick" %% "slick-hikaricp" % "3.2.2",
   "org.postgresql" % "postgresql" % "9.3-1102-jdbc41",
   "com.google.api-client" % "google-api-client" % "1.22.0",
   "com.google.http-client" % "google-http-client-jackson" % "1.22.0",


### PR DESCRIPTION
I noticed that a new version just make out now in March, so I did the upgrade.

This dependency was initially added because we were getting database connection error often and I found in slick documentation that this dependency was needed.
The database connection errors didn't disappear completely, but happen much less often making think that may be because of some issues reported at slick like https://github.com/slick/slick/issues/1814 and https://github.com/slick/slick/issues/1678, so keeping the slick dependencies up-to-date may help to completely solve the issue