### PR TITLE
168 - Remove the configuration for max and min connection

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,8 +8,6 @@ slick.dbs.default {
     url="jdbc:postgresql://"${POSTGRESQL_ADDON_HOST}":"${POSTGRESQL_ADDON_PORT}"/"${POSTGRESQL_ADDON_DB}
     user=${POSTGRESQL_ADDON_USER}
     password=${POSTGRESQL_ADDON_PASSWORD}
-    maxConnections = 4
-    minConnections = 4
   }
 }
 


### PR DESCRIPTION
Remove the configuration for max and min connection because it fails the requirement "When using queueSize > 0, maxThreads <= maxConnections is required."