### PR TITLE
LunchBot improvements

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,5 @@
 version = 3.5.9
+runner.dialect = scala212
 style = defaultWithAlign
 align.preset = more
 align.stripMargin = true

--- a/app/lunatech/lunchplanner/persistence/MenuPerDayPerPersonTable.scala
+++ b/app/lunatech/lunchplanner/persistence/MenuPerDayPerPersonTable.scala
@@ -227,7 +227,7 @@ object MenuPerDayPerPersonTable {
     connection.db.run(query)
   }
 
-  /** Get attendees for upcoming Friday lunch. The '5' refers to Friday.
+  /** Get attendees for upcoming meals up to the following 5 days
     */
   def getAttendeesEmailAddressesForUpcomingLunch(implicit
       connection: DBConnection
@@ -235,7 +235,7 @@ object MenuPerDayPerPersonTable {
     val query = sql"""SELECT u."emailAddress" FROM "MenuPerDayPerPerson" mpdpp
                       JOIN "User" u ON mpdpp."userUuid"=u."uuid" AND u."isDeleted" = FALSE
                       JOIN "MenuPerDay" mpd ON mpdpp."menuPerDayUuid"=mpd."uuid" AND mpd."isDeleted" = FALSE
-                      WHERE mpd."date" = (SELECT current_date - cast(extract(dow FROM current_date) AS int) + 5)"""
+                      WHERE mpd."date" >= (current_date + 1) AND mpd."date" <= (current_date + 5)"""
       .as[String]
     connection.db.run(query)
   }

--- a/app/lunatech/lunchplanner/persistence/MenuPerDayTable.scala
+++ b/app/lunatech/lunchplanner/persistence/MenuPerDayTable.scala
@@ -15,7 +15,6 @@ import scala.concurrent.Future
 class MenuPerDayTable(tag: Tag)
     extends Table[MenuPerDay](tag, _tableName = "MenuPerDay") {
   private val menuTable = TableQuery[MenuTable]
-  private val dishTable = TableQuery[DishTable]
 
   def uuid: Rep[UUID] = column[UUID]("uuid", O.PrimaryKey)
 
@@ -170,7 +169,8 @@ object MenuPerDayTable {
     val query =
       sql"""SELECT mpd."uuid", mpd."menuUuid", mpd."date", mpd."location", m."name"
            FROM "MenuPerDay" mpd JOIN "Menu" m ON mpd."menuUuid"=m."uuid" AND m."isDeleted" = FALSE AND mpd."isDeleted" = FALSE
-           WHERE mpd."date" = (SELECT current_date - cast(extract(dow FROM current_date) AS int) + 5)"""
+           WHERE mpd."date" >= (current_date + 1) AND mpd."date" <= (current_date + 5)
+           ORDER BY mpd."date""""
         .as[(MenuPerDay, String)]
 
     connection.db.run(query)

--- a/app/lunatech/lunchplanner/schedulers/actors/LunchBotActor.scala
+++ b/app/lunatech/lunchplanner/schedulers/actors/LunchBotActor.scala
@@ -1,17 +1,22 @@
 package lunatech.lunchplanner.schedulers.actors
 
-import akka.actor.{ Actor, ActorLogging }
-import lunatech.lunchplanner.services.{ MenuPerDayPerPersonService, SlackService, UserService }
+import akka.actor.{Actor, ActorLogging}
+import lunatech.lunchplanner.services.{
+  MenuPerDayPerPersonService,
+  SlackService,
+  UserService
+}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 class LunchBotActor(
     userService: UserService,
     menuPerDayPerPersonService: MenuPerDayPerPersonService,
     slackService: SlackService
-) extends Actor with ActorLogging {
+) extends Actor
+    with ActorLogging {
 
   override def receive: Receive = { case RunBot =>
     sendMessagesToUsers()
@@ -21,15 +26,13 @@ class LunchBotActor(
     log.info("Received RunBot message")
 
     for {
-      allEmails <- userService.getAllEmailAddresses
-      _ = log.info("Got all users email addresses")
+      allEmails        <- userService.getAllEmailAddresses
       emailsNoDecision <- getEmailAddressesOfUsersWhoHaveNoDecision(allEmails)
       _ = log.info(
-        "Got all users that have not answered on lunch planner email addresses"
+        s"Number of users that did not answer to lunch this week: ${emailsNoDecision.length}"
       )
       slackUserIds <- getSlackUserIdsByUserEmails(emailsNoDecision)
-      _ = log.info("Got all users slack users ids")
-      channelIds <- openConversation(slackUserIds)
+      channelIds   <- openConversation(slackUserIds)
       _        = log.info("Got all users channels ids")
       response = postMessages(channelIds)
     } yield response.onComplete {
@@ -47,8 +50,17 @@ class LunchBotActor(
       emailsOfAttendees => allEmails.filterNot(emailsOfAttendees.contains(_))
     )
 
-  def getSlackUserIdsByUserEmails(emails: Seq[String]): Future[Seq[String]] =
-    slackService.getAllSlackUsersByEmails(emails)
+  def getSlackUserIdsByUserEmails(
+      emails: Seq[String]
+  ): Future[Seq[String]] =
+    slackService.getAllSlackUsersByEmails(emails).map {
+      case Right(data) =>
+        log.info(s"Got all users slack users ids. Count ${data.length}")
+        data
+      case Left(error) =>
+        log.error(error)
+        Seq.empty
+    }
 
   def openConversation(slackUserIds: Seq[String]): Future[Seq[String]] =
     slackService.openConversation(slackUserIds)

--- a/app/lunatech/lunchplanner/viewModels/SlackForm.scala
+++ b/app/lunatech/lunchplanner/viewModels/SlackForm.scala
@@ -99,6 +99,9 @@ object SlackForm {
     }
   }
 
+  /** checking the result manually instead of using JsLookup.toEither to
+    * simplify the error
+    */
   def jsonToErrorMessage(json: JsValue): String = {
     val jsonResult = (json \ "error").toOption
     if (jsonResult.isDefined) {
@@ -108,12 +111,27 @@ object SlackForm {
     }
   }
 
+  /** checking the result manually instead of using JsLookup.toEither to
+    * simplify the error
+    */
   def jsonToMemberObject(json: JsValue): Either[String, Seq[Member]] = {
     val jsonResult = (json \ "members").toOption
     if (jsonResult.isDefined) {
       Right(jsonResult.get.as[Seq[Member]])
     } else {
       Left("Slack response did not have expected field 'members'.")
+    }
+  }
+
+  /** checking the result manually instead of using JsLookup.toEither to
+    * simplify the error
+    */
+  def jsonToChannelIdObject(json: JsValue): Either[String, String] = {
+    val jsonResult = (json \ "channel" \ "id").toOption
+    if (jsonResult.isDefined) {
+      Right(jsonResult.get.as[String])
+    } else {
+      Left("Slack response did not have expected field 'channel \\ id'.")
     }
   }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,12 +54,12 @@ slack.bot {
   cron = "0 0 10 ? * 3" // 0 sec / 0 min / 10h  /any day of month / every month / 3rd day of week (Tuesday)
   cron = ${?SLACK_BOT_CRON}
   host = ${?SLACK_HOST_NAME}
-  message.text="Hello. LunchBot here. :robot_face:"
-  attachment.text="We're going to have %s this Friday. Will you join us? *Please be aware that if you don't choose an option you cannot expect Lunatech to provide you lunch.*"
-  button.yes.text="I'll have %s in %s."
+  message.salutation="Hello. LunchBot here. :robot_face:\nPlease let me know if you will join us at the following occasions, so that we can provide you lunch. (You can still change your mind and let us know at lunch.lunatech.nl!)"
+  attachment.text="*Day*: %s\n*Where*: %s\n*Menu*: %s"
+  button.yes.text="Yes, count me in in %s!"
   button.no.text="Nope. :no_good:"
   response.notAttending.text="Alright. If you change your mind, or *if you don wan't to see these messages*, just go to lunch.lunatech.nl. :grinning:"
-  response.text="You picked %s :grinning: If you change your mind, or *if you don wan't to see these messages*, just go to lunch.lunatech.nl and pick an option for the following weeks!"
+  response.text="Thanks, %s we'll see you in %s! :grinning:"
 }
 
 akka.http.server.parsing.illegal-header-warnings = off

--- a/dockerdev/postgres/Dockerfile
+++ b/dockerdev/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.5
+FROM postgres:11
 
 RUN apt-get update \
       && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
LunchBot improvements:
- Consider lunches on all days of the week (not just Friday)
- Send separate messages, to allow users to signup for more than one day
- Check if Slack responded with a successful or unsuccessful and log errors