### PR TITLE
Add rest endpoint to retrieve future events information

### DIFF
--- a/app/lunatech/lunchplanner/controllers/RestController.scala
+++ b/app/lunatech/lunchplanner/controllers/RestController.scala
@@ -1,17 +1,26 @@
 package lunatech.lunchplanner.controllers
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 import com.google.inject.Inject
 import play.api._
 import play.api.i18n.I18nSupport
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._
-import lunatech.lunchplanner.services.UserService
+import lunatech.lunchplanner.services.{
+  DishService,
+  MenuDishService,
+  MenuPerDayService,
+  MenuService,
+  RestService,
+  UserService
+}
 import com.lunatech.openconnect.{APISessionCookieBaker, GoogleApiSecured}
+import lunatech.lunchplanner.models.{Event, MenuPerDay, MenuWithDishes, User}
 
 class RestController @Inject() (
     userService: UserService,
+    restService: RestService,
     val apiSessionCookieBaker: APISessionCookieBaker,
     val configuration: Configuration,
     override val controllerComponents: ControllerComponents
@@ -34,5 +43,23 @@ class RestController @Inject() (
           case Some(user) => Ok(Json.toJson(user))
           case None       => NotFound("User not found")
         }
+  }
+
+  /** Get future events, including current user attendance
+    *
+    * @param limit
+    *   Up to how many months in the future to look into
+    * @return
+    *   A list of Events, including user attendance and dishes
+    */
+  def getFutureEvents(limit: Int): Action[AnyContent] = userAction.async {
+    implicit request =>
+      userService.getByEmailAddress(emailAddress = request.email).flatMap {
+        case Some(user: User) =>
+          restService.getFutureEvents(user, limit).map { events: Seq[Event] =>
+            Ok(Json.toJson(events))
+          }
+        case None => Future.successful(NotFound("User not found"))
+      }
   }
 }

--- a/app/lunatech/lunchplanner/models/Dish.scala
+++ b/app/lunatech/lunchplanner/models/Dish.scala
@@ -1,9 +1,11 @@
 package lunatech.lunchplanner.models
 
-import play.api.libs.json.{Json, OFormat}
-
+import play.api.libs.json.{JsPath, Json, OFormat, Writes}
 import java.util.UUID
+
 import scala.collection.mutable.ListBuffer
+
+import play.api.libs.functional.syntax.{toFunctionalBuilderOps, unlift}
 
 final case class Dish(
     uuid: UUID = UUID.randomUUID(),
@@ -43,4 +45,20 @@ object Dish {
 
     list.toList
   }
+
+  implicit val writer: Writes[Dish] =
+    (JsPath \ "uuid")
+      .write[UUID]
+      .and((JsPath \ "name").write[String])
+      .and((JsPath \ "description").write[String])
+      .and((JsPath \ "isVegetarian").write[Boolean])
+      .and((JsPath \ "isHalal").write[Boolean])
+      .and((JsPath \ "hasSeaFood").write[Boolean])
+      .and((JsPath \ "hasPork").write[Boolean])
+      .and((JsPath \ "hasBeef").write[Boolean])
+      .and((JsPath \ "hasChicken").write[Boolean])
+      .and((JsPath \ "isGlutenFree").write[Boolean])
+      .and((JsPath \ "hasLactose").write[Boolean])
+      .and((JsPath \ "remarks").write[Option[String]])
+      .and((JsPath \ "isDeleted").write[Boolean])(unlift(Dish.unapply))
 }

--- a/app/lunatech/lunchplanner/models/Event.scala
+++ b/app/lunatech/lunchplanner/models/Event.scala
@@ -1,0 +1,42 @@
+package lunatech.lunchplanner.models
+
+import java.sql.Date
+import java.util.UUID
+
+import play.api.libs.functional.syntax.{toFunctionalBuilderOps, unlift}
+import play.api.libs.json.{JsPath, Writes}
+
+/**
+ * This object is a composite, similar to MenuPerDay but containing more related data
+ * @param menuUuid Menu UUID
+ * @param menuPerDayUuid MenuPerDay UUID
+ * @param name Menu name
+ * @param date MenuPerDay date
+ * @param location MenuPerDay location
+ * @param attending is the current user attending
+ * @param attendees number of attendees
+ * @param availableDishes available dishes
+ */
+case class Event(
+    menuUuid: UUID,
+    menuPerDayUuid: UUID,
+    name: String,
+    date: Date,
+    location: String,
+    attending: Boolean,
+    attendees: Int,
+    availableDishes: Seq[Dish]
+)
+
+object Event {
+  implicit val writer: Writes[Event] =
+    (JsPath \ "menuUuid")
+      .write[UUID]
+      .and((JsPath \ "menuPerDayUuid").write[UUID])
+      .and((JsPath \ "name").write[String])
+      .and((JsPath \ "date").write[Date])
+      .and((JsPath \ "location").write[String])
+      .and((JsPath \ "attending").write[Boolean])
+      .and((JsPath \ "attendees").write[Int])
+      .and((JsPath \ "availableDishes").write[Seq[Dish]])(unlift(Event.unapply))
+}

--- a/app/lunatech/lunchplanner/persistence/MenuPerDayTable.scala
+++ b/app/lunatech/lunchplanner/persistence/MenuPerDayTable.scala
@@ -89,16 +89,20 @@ object MenuPerDayTable {
     connection.db.run(query.result)
   }
 
-  def getAllFutureAndOrderedByDateAscending(implicit
+  def getAllFutureAndOrderedByDateAscending(limit: Option[Int] = None)(implicit
       connection: DBConnection
   ): Future[Seq[MenuPerDay]] = {
-    val query = menuPerDayTable
+    val filter: Query[MenuPerDayTable, MenuPerDay, Seq] = menuPerDayTable
       .filter(mpd =>
         mpd.isDeleted === false && mpd.date >= new Date(
           LocalDateTime.now().toInstant(ZoneOffset.UTC).toEpochMilli
         )
       )
-      .sortBy(mpd => mpd.date)
+    val take = limit match {
+      case Some(value) => filter.take(value)
+      case None        => filter
+    }
+    val query = take.sortBy(mpd => mpd.date)
     connection.db.run(query.result)
   }
 

--- a/app/lunatech/lunchplanner/services/MenuDishService.scala
+++ b/app/lunatech/lunchplanner/services/MenuDishService.scala
@@ -2,15 +2,16 @@ package lunatech.lunchplanner.services
 
 import lunatech.lunchplanner.common.DBConnection
 import lunatech.lunchplanner.models.{
+  Dish,
   DishIsSelected,
   MenuDish,
   MenuWithAllDishesAndIsSelected,
   MenuWithDishes
 }
 import lunatech.lunchplanner.persistence.MenuDishTable
-
 import java.util.UUID
 import javax.inject.Inject
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -21,6 +22,16 @@ class MenuDishService @Inject() (
 
   def add(menuDish: MenuDish): Future[MenuDish] =
     MenuDishTable.add(menuDish)
+
+  def getMenuListOfDishes(menuUuid: UUID): Future[Seq[Dish]] =
+    for {
+      menuDishes: Seq[MenuDish] <- MenuDishTable.getByMenuUuid(menuUuid)
+      dishes <- Future
+        .sequence(
+          menuDishes.map(dish => dishService.getByUuid(dish.dishUuid))
+        )
+        .map(_.flatten)
+    } yield dishes
 
   def getAllWithListOfDishes: Future[Seq[MenuWithDishes]] =
     for {

--- a/app/lunatech/lunchplanner/services/MenuPerDayPerPersonService.scala
+++ b/app/lunatech/lunchplanner/services/MenuPerDayPerPersonService.scala
@@ -126,7 +126,7 @@ class MenuPerDayPerPersonService @Inject() (
       } yield result
 
     for {
-      menuPerDays <- menuPerDayService.getAllFutureAndOrderedByDate
+      menuPerDays <- menuPerDayService.getAllFutureAndOrderedByDate()
       result      <- Future.traverse(menuPerDays)(getMenuDetails).map(_.flatten)
     } yield result
   }
@@ -180,6 +180,13 @@ class MenuPerDayPerPersonService @Inject() (
     } yield attendees.map { case (user: User, userProfile: UserProfile) =>
       MenuPerDayAttendant(user.name, userProfile.otherRestriction.getOrElse(""))
     }
+
+  def getUsersByMenuPerDay(
+      menuPerDayUuid: UUID
+  ): Future[Seq[(User, UserProfile)]] =
+    MenuPerDayPerPersonTable.getAttendeesByMenuPerDayUuid(
+      menuPerDayUuid
+    )
 
   def getListOfPeopleByMenuPerDayForReport(
       menuPerDay: MenuPerDay

--- a/app/lunatech/lunchplanner/services/MenuPerDayService.scala
+++ b/app/lunatech/lunchplanner/services/MenuPerDayService.scala
@@ -18,8 +18,10 @@ class MenuPerDayService @Inject() (menuService: MenuService)(implicit
 
   def getAll: Future[Seq[MenuPerDay]] = MenuPerDayTable.getAll
 
-  def getAllFutureAndOrderedByDate: Future[Seq[MenuPerDay]] =
-    MenuPerDayTable.getAllFutureAndOrderedByDateAscending
+  def getAllFutureAndOrderedByDate(
+      limit: Option[Int] = None
+  ): Future[Seq[MenuPerDay]] =
+    MenuPerDayTable.getAllFutureAndOrderedByDateAscending(limit)
 
   def getAllOrderedByDateFilterDateRange(
       dateStart: Date,

--- a/app/lunatech/lunchplanner/services/RestService.scala
+++ b/app/lunatech/lunchplanner/services/RestService.scala
@@ -1,0 +1,64 @@
+package lunatech.lunchplanner.services
+
+import java.sql.Date
+import java.text.SimpleDateFormat
+import java.time.temporal.{ChronoUnit, TemporalUnit}
+import java.time.{Instant, LocalDateTime, ZoneOffset}
+import javax.inject.Inject
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+import lunatech.lunchplanner.common.DBConnection
+import lunatech.lunchplanner.models.{
+  Dish,
+  Event,
+  Menu,
+  MenuPerDay,
+  MenuPerDayAttendant,
+  MenuPerDayDietRestrictions,
+  MenuWithNamePerDay,
+  User,
+  UserProfile
+}
+
+class RestService @Inject() (
+    menuService: MenuService,
+    menuPerDayService: MenuPerDayService,
+    menuPerDayPerPersonService: MenuPerDayPerPersonService,
+    menuDishService: MenuDishService
+)(implicit val connection: DBConnection) {
+  def getFutureEvents(user: User, limit: Int): Future[Seq[Event]] = {
+    def getMenuDetails(
+        menuPerDay: MenuPerDay
+    ): Future[Option[Event]] =
+      for {
+        menu <- menuService.getByUuid(menuPerDay.menuUuid)
+        dishes: Seq[Dish] <- menuDishService
+          .getMenuListOfDishes(menuPerDay.menuUuid)
+        attendees: Seq[(User, UserProfile)] <- menuPerDayPerPersonService
+          .getUsersByMenuPerDay(menuPerDay.uuid)
+      } yield menu.map { menu =>
+        Event(
+          menuUuid = menuPerDay.menuUuid,
+          menuPerDayUuid = menuPerDay.uuid,
+          name = menu.name,
+          date = menuPerDay.date,
+          location = menuPerDay.location,
+          attending = attendees.exists { case (attendingUser, _) =>
+            attendingUser.uuid == user.uuid
+          },
+          attendees = attendees.size,
+          availableDishes = dishes
+        )
+      }
+
+    for {
+      menuPerDays: Seq[MenuPerDay] <- menuPerDayService
+        .getAllFutureAndOrderedByDate(Some(limit))
+      result: Seq[Event] <- Future
+        .traverse(menuPerDays)(getMenuDetails)
+        .map(_.flatten)
+    } yield result
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
-githubOwner := "lunatech-labs"
+githubOwner      := "lunatech-labs"
 githubRepository := "lunatech-lunch-planner"
 githubTokenSource := TokenSource.Environment("GITHUB_TOKEN") || TokenSource
   .GitConfig("github.token")

--- a/conf/routes
+++ b/conf/routes
@@ -51,6 +51,7 @@ GET         /menuPerDayPerPerson/attendees     lunatech.lunchplanner.controllers
 
 # Rest API
 GET        /api/users                          lunatech.lunchplanner.controllers.RestController.getUser(email: String)
+GET        /api/events                         lunatech.lunchplanner.controllers.RestController.getFutureEvents(limit: Int ?= 2)
 
 # Map static resources from the /public folder to the /assets URL path
 GET         /assets/*file                      controllers.Assets.at(path="/public", file)

--- a/test/lunatech/lunchplanner/data/ControllersData.scala
+++ b/test/lunatech/lunchplanner/data/ControllersData.scala
@@ -1,9 +1,12 @@
 package lunatech.lunchplanner.data
 
+import java.sql.Date
+import java.time.Instant
 import java.util.UUID
 
 import lunatech.lunchplanner.models.{
   Dish,
+  Event,
   Menu,
   MenuWithDishes,
   MenuWithNamePerDay,
@@ -12,6 +15,7 @@ import lunatech.lunchplanner.models.{
 }
 import play.api.libs.json.{JsValue, Json}
 
+// scalastyle:off magic.number
 object ControllersData {
 
   val createNewDishJson: JsValue = Json.parse("""
@@ -149,4 +153,27 @@ object ControllersData {
   val userProfile2 = UserProfile(glutenRestriction = true)
   val userProfile3 = UserProfile(lactoseRestriction = true)
   val userProfile4 = UserProfile(vegetarian = true)
+
+  val event1MenuUuid       = UUID.randomUUID
+  val event1MenuPerDayUuid = UUID.randomUUID
+  val event1Epoch          = Instant.now().plusSeconds(3600).toEpochMilli
+  val dish1Uuid            = UUID.randomUUID
+  val event1 = Event(
+    menuUuid = event1MenuUuid,
+    menuPerDayUuid = event1MenuPerDayUuid,
+    name = "Lunch1",
+    date = new Date(event1Epoch),
+    location = "Rotterdam",
+    attending = false,
+    attendees = 3,
+    availableDishes = Seq(
+      Dish(
+        uuid = dish1Uuid,
+        name = "Bitterballen",
+        description = "",
+        hasBeef = true
+      )
+    )
+  )
+  val events = Seq(event1)
 }

--- a/test/lunatech/lunchplanner/models/JsonSpec.scala
+++ b/test/lunatech/lunchplanner/models/JsonSpec.scala
@@ -1,0 +1,65 @@
+package lunatech.lunchplanner.models
+
+import java.util.UUID
+
+import lunatech.lunchplanner.data.ControllersData
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import play.api.libs.json.Json
+
+class JsonSpec extends AnyFlatSpec with Matchers {
+  "User model" should "write it's JSON representation correctly" in {
+    val uuid = UUID.randomUUID()
+    val user = User(
+      uuid = uuid,
+      name = "user",
+      emailAddress = "user@test.com",
+      isAdmin = true
+    )
+    val expected = s"""
+                  |{
+                  |    "uuid":"${uuid.toString}",
+                  |    "name":"user",
+                  |    "emailAddress":"user@test.com",
+                  |    "isAdmin":true,
+                  |    "isDeleted":false
+                  |}
+                 """.stripMargin.stripTrailing().filterNot(_.isWhitespace)
+    Json.toJson(user).toString() shouldBe expected
+  }
+
+  "Event model" should "write it's JSON representation correctly" in {
+    val events = ControllersData.events
+    val expected = s"""
+                      |[
+                      |    {
+                      |        "menuUuid":"${ControllersData.event1MenuUuid.toString}",
+                      |        "menuPerDayUuid":"${ControllersData.event1MenuPerDayUuid.toString}",
+                      |        "name":"Lunch 1",
+                      |        "date":${ControllersData.event1Epoch},
+                      |        "location":"Rotterdam",
+                      |        "attending":false,
+                      |        "attendees":3,
+                      |        "availableDishes": [
+                      |            {
+                      |                "uuid":"${ControllersData.dish1Uuid.toString}",
+                      |                "name":"Bitterballen",
+                      |                "description":"",
+                      |                "isVegetarian":false,
+                      |                "isHalal":false,
+                      |                "hasSeaFood":false,
+                      |                "hasPork":false,
+                      |                "hasBeef":true,
+                      |                "hasChicken":false,
+                      |                "isGlutenFree":false,
+                      |                "hasLactose":false,
+                      |                "isDeleted":false
+                      |            }
+                      |        ]
+                      |    }
+                      |]
+                 """.stripMargin.stripTrailing().filterNot(_.isWhitespace)
+    Json.toJson(events).toString() shouldBe expected
+  }
+}

--- a/test/lunatech/lunchplanner/persistence/MenuPerDayTableSpec.scala
+++ b/test/lunatech/lunchplanner/persistence/MenuPerDayTableSpec.scala
@@ -181,7 +181,7 @@ object MenuPerDayTableSpec
 
       val result =
         Await.result(
-          MenuPerDayTable.getAllFutureAndOrderedByDateAscending,
+          MenuPerDayTable.getAllFutureAndOrderedByDateAscending(),
           defaultTimeout
         )
 


### PR DESCRIPTION
Add a new rest endpoint with all information required to use on the main view of the mobile lunch app.
- Allows limiting how many months in the future to look up
- Aggregates all information for an event on a single object, including menu and dish information, also whether the user requesting is attending

<img width="1319" alt="Screenshot 2022-10-25 at 11 27 58" src="https://user-images.githubusercontent.com/13895270/197744640-7af81edb-2134-4029-901d-92d90a75375a.png">
